### PR TITLE
Winrm authentication fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,9 @@ $ADFS_IP          = "#{$NET_PREFIX}.53"
 $LAB_NET_PATTERN  = "#{$NET_PREFIX}.*"
 
 Vagrant.configure(2) do |config|
+  config.winrm.transport = :plaintext
+  config.winrm.basic_auth_only = true
+
   config.vm.provider "virtualbox" do |vb|
 #     vb.gui = false
 #     vb.customize ["modifyvm", :id, "--memory", "1024"]


### PR DESCRIPTION
I was running into issues with winrm connectivity after the domain controller was built but the fix in issue #1 didn't work for me. Setting the winrm transport to plaintext and basic auth works for me even without the Start-Sleep.

Let me know your thoughts.
